### PR TITLE
fix issue #24

### DIFF
--- a/LPFilter/Source/PluginProcessor.cpp
+++ b/LPFilter/Source/PluginProcessor.cpp
@@ -127,10 +127,13 @@ void LpfilterAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlo
     iirCoef = IIRCoefficients::makeLowPass(sampleRate, *frequency);
     
     // Set up previous buffer for custom filter
-    prevBuffer.setSize(getTotalNumInputChannels(), samplesPerBlock);
+    prevBuffer.setSize(getMainBusNumInputChannels(), samplesPerBlock);
     prevBuffer.clear();
     
     filteredBuffer.setSize(2, samplesPerBlock);
+    
+    // Set previous frequncy to current frequency
+    previousFrequency = *frequency;
 }
 
 
@@ -176,7 +179,9 @@ void LpfilterAudioProcessor::processBlock (AudioSampleBuffer& ioBuffer, MidiBuff
     
     
     //Update frequency parameter
-    updateParameters();
+    
+    if (previousFrequency != *frequency)
+        updateParameters();
     
     if (! *bypass)
     {
@@ -197,7 +202,7 @@ void LpfilterAudioProcessor::processBlock (AudioSampleBuffer& ioBuffer, MidiBuff
         }
         else
         {
-            jassert(mode->getIndex()<=2);
+            jassertfalse;
         }
         
         // Apply gain
@@ -286,6 +291,8 @@ void LpfilterAudioProcessor::updateParameters()
     
     // Update custom filter coeffiecients
     iirCoef = IIRCoefficients::makeLowPass(getSampleRate(), *frequency);
+    
+    previousFrequency = *frequency;
 }
 
 //==============================================================================

--- a/LPFilter/Source/PluginProcessor.h
+++ b/LPFilter/Source/PluginProcessor.h
@@ -68,6 +68,7 @@ private:
     //==============================================================================
     AudioParameterFloat* gain;
     AudioParameterFloat* frequency;
+    float previousFrequency;
     AudioParameterChoice* mode;
     AudioParameterBool* bypass;
     IIRCoefficients      iirCoef;

--- a/LPFilter/Source/PluginProcessor.h
+++ b/LPFilter/Source/PluginProcessor.h
@@ -71,11 +71,9 @@ private:
     AudioParameterChoice* mode;
     AudioParameterBool* bypass;
     IIRCoefficients      iirCoef;
-
     Dsp::Params paramsDsp;
     
     dsp::ProcessorDuplicator<dsp::IIR::Filter<float>, dsp::IIR::Coefficients<float>> lpfJuce;
-    
     ScopedPointer<Dsp::Filter> lpfDspLib;
     
     AudioSampleBuffer prevBuffer;

--- a/LPFilter/Source/PluginProcessor.h
+++ b/LPFilter/Source/PluginProcessor.h
@@ -73,7 +73,6 @@ private:
     IIRCoefficients      iirCoef;
 
     Dsp::Params paramsDsp;
-    float defaultFreq = 60.f;
     
     dsp::ProcessorDuplicator<dsp::IIR::Filter<float>, dsp::IIR::Coefficients<float>> lpfJuce;
     


### PR DESCRIPTION
# About `lpfDspLib` and `filteredBuffer`
`lpfDspLib` is a LPF designed with the **DSPFilters** library using the template class `FilterDesign`. This class requires a constant expression for the number of channels (`template <class DesignClass, int Channels = 0, class StateType = DirectFormII> class FilterDesign`).  
As a result, a variable that contains the number of channels, cannot be used and `filteredBuffer` cannot be avoided.

# About `ProcessorDuplicator`
`ProcessorDuplicator` converts a mono processor (like `dsp::IIR::Filter` class) into a multi-channel version by duplication . The `numChannels` info is passed into `ProcessSpec` class, which is used in the `prepare()` method of the `ProcessorDuplicator` to create an `OwnedArray` of mono processors of size `numChannels`. 
It seems to me that `ProcessorDuplicator` is, in fact, needed.
